### PR TITLE
Replaced manually using grim + slurp to using grimblast

### DIFF
--- a/.config/scripts/screenshot.sh
+++ b/.config/scripts/screenshot.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 CHOICE=$(echo -e "Full Screen\nSelect Region" | rofi -dmenu -p "Screenshot:" -theme ~/.config/rofi/style.rasi)
+timestamp=$(date +'%Y-%m-%d_%H-%M-%S')
+file="$HOME/Pictures/screenshot-$timestamp.png"
 
 case "$CHOICE" in
   "Full Screen")
-        timestamp=$(date +'%Y-%m-%d_%H-%M-%S') && grim ~/Pictures/screenshot-$timestamp.png && wl-copy --type image/png < ~/Pictures/screenshot-$timestamp.png
+    grimblast copysave screen "$file"
     ;;
   "Select Region")
-        timestamp=$(date +'%Y-%m-%d_%H-%M-%S') && grim -g "$(slurp)" ~/Pictures/screenshot-$timestamp.png && wl-copy --type image/png < ~/Pictures/screenshot-$timestamp.png
+    grimblast copysave area "$file"
     ;;
   *)
     exit 1
     ;;
 esac
-


### PR DESCRIPTION
## 📦 Summary (Short Description)
Simplified screenshot script by replacing manual `grim` + `slurp` combination with `grimblast` for cleaner, more maintainable code.

---
## 🚀 Major Updates (Breaking or high-impact changes)
None

---
## ✨ Minor Updates (Enhancements or small changes)
- Replaced manual grim + slurp invocation with grimblast in screenshot.sh for improved maintainability

---
## 🐞 Fixes (Bug fixes or corrections)
None

---
## 📁 Additional Notes / Migration Steps (if needed)
None

